### PR TITLE
Adds Docker setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 .DS_Store
 dev_bundle
+app/.env

--- a/app/.dockerignore
+++ b/app/.dockerignore
@@ -1,0 +1,4 @@
+.dockerignore
+Dockerfile
+docker-compose.yml
+.env

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,2 @@
+FROM meteorhacks/meteord:onbuild
+MAINTAINER Benjamin Adams <Ben.Adams@rpsgroup.com>

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '2'
+
+services:
+  catalog-harvest-registry:
+    build: .
+    env_file: .env
+    ports:
+      - '80:80'
+
+  mongo:
+    image: mongo:3.2


### PR DESCRIPTION
Adds Dockerfile and docker-compose.yml, while exlcuding them from being
pushed to server with .dockerignore.  Requires a way of passing in
environment variables for at least ROOT_URL and MONGO_URL environments
variables, such as a .env file referenced in docker-compose, which is
the default.
