### PR TITLE
Several UX fixes

### DIFF
--- a/app/imports/api/harvests/harvests.js
+++ b/app/imports/api/harvests/harvests.js
@@ -48,11 +48,7 @@ export const HarvestsTable = new Tabular.Table({
       tmpl: Meteor.isClient && Template.harvestLink
     },
     {
-      title: "Type",
-      data: "harvest_type"
-    },
-    {
-      title: "Published?",
+      title: "Online",
       data: "publish",
       tmpl: Meteor.isClient && Template.harvestPublished
     },
@@ -75,7 +71,7 @@ export const HarvestsTable = new Tabular.Table({
       }
     }
   ],
-  extraFields: ['harvest_interval', 'last_good_count', 'last_bad_count']
+  extraFields: ['harvest_type', 'harvest_interval', 'last_good_count', 'last_bad_count']
 });
 
 const HarvestSchema = new SimpleSchema({

--- a/app/imports/api/records/server/methods.js
+++ b/app/imports/api/records/server/methods.js
@@ -10,7 +10,10 @@ Meteor.methods({
   'records.errorCount'({harvestId}) {
     check(harvestId, String);
     let errorCount = 0;
-    Records.find({harvest_id: harvestId}, {validation_errors: 1}).forEach((record)=> {
+    Records.find({
+      harvest_id: harvestId, 
+      validation_errors: {$exists: true, $ne: []}
+    }, {validation_errors: 1}).forEach((record)=> {
       errorCount += record.validation_errors.length;
     });
     return errorCount;
@@ -18,7 +21,10 @@ Meteor.methods({
   'records.servicesCount'({harvestId}) {
     let count = 0;
     check(harvestId, String);
-    Records.find({harvest_id: harvestId}, {services: 1}).forEach(function(record) {
+    Records.find({
+      harvest_id: harvestId,
+      services: {$exists: true, $ne: []}
+    }, {services: 1}).forEach(function(record) {
       count += record.services.length;
     });
     return count;

--- a/app/imports/startup/client/routes.js
+++ b/app/imports/startup/client/routes.js
@@ -47,6 +47,15 @@ FlowRouter.route('/harvests', {
   }
 });
 
+FlowRouter.route('/harvests/:harvestId', {
+  name: 'harvests',
+  action() {
+    validatedRender((error, response) => {
+      BlazeLayout.render('MasterLayout', {yield: "harvests"});
+    });
+  }
+});
+
 /****************************************/
 /* Users */
 /****************************************/

--- a/app/imports/ui/components/harvests/dashboard-heading.jade
+++ b/app/imports/ui/components/harvests/dashboard-heading.jade
@@ -1,30 +1,23 @@
 template(name="dashboardHeading")
-  .row.box-header
-    if _id
-      .box.box-3#sources-box
-        h3.blue
-          i.fa.fa-database
-          span Data Sources 
-          span.badge= dataSources
-
-      .box.box-3#records
-        h3.green
-          i.fa.fa-file
-          span Records
-          span.badge= records
-      .box.box-3
-        h3.murple
-          i.fa.fa-cloud-download
-          span Attempts
-          span.badge= attempts
-      .box.box-3
-        h3.red
-          i.fa.fa-warning
-          span Errors
-          span.badge= errors
-    else
-      .box.box-12#sources-box
-        h3.blue
-          i.fa.fa-database
-          span Data Sources 
-          span.badge= dataSources
+  if _id
+    .box.col-md-6
+      h3.blue
+        i.fa.fa-database
+        span Data Sources 
+        span.badge= dataSources
+    .box.col-md-3#records
+      h3.green
+        i.fa.fa-file
+        span Total Records
+        span.badge= records
+    .box.col-md-3#errors
+      h3.red
+        i.fa.fa-warning
+        span Bad Records
+        span.badge= errors
+  else
+    .box.col-md-12#sources-box
+      h3.blue
+        i.fa.fa-database
+        span Data Sources 
+        span.badge= dataSources

--- a/app/imports/ui/components/harvests/dashboard-heading.js
+++ b/app/imports/ui/components/harvests/dashboard-heading.js
@@ -7,6 +7,11 @@ import { ReactiveDict } from 'meteor/reactive-dict';
 import { _ } from 'meteor/underscore';
 
 Template.dashboardHeading.events({
+  'click #errors'(){
+    if(!_.isUndefined(this._id)) {
+      FlowRouter.go('records', {harvestId: this._id});
+    }
+  },
   'click #records'() {
     if(!_.isUndefined(this._id)) {
       FlowRouter.go('records', {harvestId: this._id});

--- a/app/imports/ui/components/harvests/harvests-chart.jade
+++ b/app/imports/ui/components/harvests/harvests-chart.jade
@@ -18,4 +18,8 @@ template(name="harvestSummary")
       if isHarvesting
         i.fa.fa-spinner.fa-spin
       else
+        | Last Harvest: 
         = harvestDate
+   p
+     a(href=url target="_blank")= url
+

--- a/app/imports/ui/components/harvests/harvests-chart.js
+++ b/app/imports/ui/components/harvests/harvests-chart.js
@@ -119,6 +119,9 @@ var addDonutChart = function(selector, data) {
           .transition().duration(350)
           .call(chart);
 
+    for(var property in chart.legend.dispatch) {
+      chart.legend.dispatch[property] = function() {};
+    }
     return chart;
   });
 };
@@ -138,11 +141,11 @@ Template.harvestsChart.renderChart = function() {
   addDonutChart("#chart svg", () => {
     return  [
         { 
-          "label": "Good",
+          "label": "Clean Records",
           "value" : good
         } , 
         { 
-          "label": "Errors",
+          "label": "Bad Records",
           "value" : bad
         }
       ];

--- a/app/imports/ui/components/harvests/harvests-table.js
+++ b/app/imports/ui/components/harvests/harvests-table.js
@@ -6,21 +6,24 @@ import { Harvests, HarvestsTable } from '/imports/api/harvests/harvests.js';
 /* harvestsTable: Event Handlers */
 /*****************************************************************************/
 Template.harvestsTable.events({
+  'click a'(event, instance) {
+    event.stopPropagation();
+  },
   'click tr'(event, instance) {
     let dataTable = $(event.target).closest('table').DataTable();
     let table = $(event.target).closest('table');
     $(table).find('tr').removeClass('active');
     let rowData = dataTable.row(event.currentTarget).data();
     if (!rowData) {
-      $('#harvests-table').removeClass('box-6').addClass('box-12');
-      $('#sources-box').removeClass('box-3').addClass('box-12');
+      $('#harvests-table-box').removeClass('col-md-6').addClass('col-md-12');
+      $('#sources-box').removeClass('col-md-6').addClass('box-12');
       Meteor.setTimeout(() => {
         instance.state.set('harvestId', null);
       }, 500);
     } else {
       $(event.target).closest('tr').addClass('active');
-      $('#harvests-table').removeClass('box-12').addClass('box-6');
-      $('#sources-box').removeClass('box-12').addClass('box-3');
+      $('#harvests-table-box').removeClass('col-md-12').addClass('col-md-6');
+      $('#sources-box').removeClass('col-md-12').addClass('col-md-6');
       Meteor.setTimeout(() => {
         instance.state.set('harvestId', rowData._id);
       }, 500);

--- a/app/imports/ui/pages/harvests/harvests.jade
+++ b/app/imports/ui/pages/harvests/harvests.jade
@@ -6,25 +6,28 @@ template(name='harvests')
           | &nbsp;&nbsp;+
     .page-breadcrumbs
       | / Harvests
-  .harvests
-    +Template.dynamic template="dashboardHeading" data=activeHarvest
-    .row
-      if harvestSelected
-        .box.box-6.box-table.box-table-sm#harvests-table
-          +harvestsTable
+  .harvests.resource
+    .container.stretch
+      .row
+        .box-header
+          +Template.dynamic template="dashboardHeading" data=activeHarvest
+      .row
+        if harvestSelected
+          .box.box-table.col-md-6.col-xs-12#harvests-table-box
+            +harvestsTable
 
-        .box.box-6
-          if editMode
-            +harvestsEdit
-          else
-            +Template.dynamic template="harvestsChart" data=activeHarvest
-      else
-        .box.box-12.box-table#harvests-table
-          +harvestsTable
+          .box.col-md-6.col-xs-12
+            if editMode
+              +harvestsEdit
+            else
+              +Template.dynamic template="harvestsChart" data=activeHarvest
+        else
+          .box.box-table.col-md-12.col-xs-12#harvests-table-box
+            +harvestsTable
 
 
 template(name="harvestLink")
-  a(href=url)
+  a(href=url target="_blank")
     {{parseUrl url}}
 
 template(name="harvestPublished")
@@ -35,5 +38,5 @@ template(name="harvestPublished")
 
 template(name="harvestCKANLink")
   if ckanHarvestURL
-    a(href=ckanHarvestURL)
+    a(href=ckanHarvestURL target="_blank")
       img.ckan-logo(alt="CKAN Logo" src="{{absoluteUrl 'images/logo-ckan.svg'}}")

--- a/app/imports/ui/pages/harvests/harvests.js
+++ b/app/imports/ui/pages/harvests/harvests.js
@@ -51,7 +51,15 @@ Template.harvests.helpers({
     return Harvests.findOne({_id: harvestId});
   },
   harvestSelected() {
-    let somethingSelected = Template.instance().state.get('harvestId') !== null;
+    /*
+     * If the subscription hasn't finished, getting a harvest will return
+     * undefined. This helper will be triggered again by the invalidation once
+     * the subscription is done, at that point findOne will return a
+     * dictionary of the harvest object.
+     */
+    let harvestId = Template.instance().state.get('harvestId');
+    let somethingSelected = harvestId !== null && 
+                            !_.isEmpty(Harvests.findOne({_id: harvestId}));
     let editMode = Template.instance().state.get('editMode');
     return somethingSelected || editMode;
   }
@@ -63,9 +71,10 @@ Template.harvests.onCreated(function() {
     this.subscribe('harvests.public');
     this.subscribe('organizations');
   });
+  let harvestId = FlowRouter.getParam('harvestId') || null;
   // This is the referenced doc for the reset of the page. It gets set when a
   // user selects certain elements, like a row in a table of harvests.
-  this.state.set("harvestId", null);
+  this.state.set("harvestId", harvestId);
   // This flag causes the edit form to appear
   this.state.set('editMode', false);
   // This list contains the documents that are actively being harvested

--- a/app/imports/ui/pages/harvests/harvests.less
+++ b/app/imports/ui/pages/harvests/harvests.less
@@ -1,54 +1,24 @@
 /*****************************************************************************/
 /* harvests: Style */
 /*****************************************************************************/
+@import "../../stylesheets/resource";
 @import "../../stylesheets/variables";
 
 @box-height: 454px;
 @background-gray: #F5F5F5;
 
-.harvests .box-3,
-.harvests .box-6{
-    width: 100%;
-    padding-bottom: 20px;
-}
-
 .harvests {
     
-    background-color: @background-gray;
-    padding-top: 20px;
-    padding-bottom: 40px;
-    font-family: "Roboto", sans-serif;
-    color: rgb(153, 153, 153);
-
     a {
         color: rgb(0, 147, 178);
-    }
-    h3 {
-      font-family: "Roboto Slab", Times, serif;
-      margin-bottom: 20px;
-    }
-    h3.blue {
-        color: @color-data-sources;
-    }
-    h3.green {
-        color: @color-records;
-    }
-    h3.red {
-        color: @color-errors;
-    }
-    h3.murple {
-        color: @color-notifications;
-    }
-    .box {
-        display: inline-block;
-        border-radius: 5px;
-        vertical-align: top;
-        background-color: white;
     }
     .box-header .box {
         cursor: default;
     }
     .box-header .box#records {
+        cursor: pointer;
+    }
+    .box-header .box#errors {
         cursor: pointer;
     }
     .box.box-hover {
@@ -80,19 +50,7 @@
     }
 
     // Mobile sizing
-    .row {
-        padding-bottom: 20px;
-        margin-left: 0;
-        margin-right: 0;
-    }
 
-    .box {
-        padding: 0px 10px;
-        min-height: 20px;
-        margin-left: 5px;
-        margin-right: 5px;
-        width: 100%;
-    }
     #chart {
         width: 400px;
         height: 400px;

--- a/app/imports/ui/pages/records/records.jade
+++ b/app/imports/ui/pages/records/records.jade
@@ -1,8 +1,15 @@
 template(name='records')
   .title-crumbs
     .page-title
-      h2 Records
+      h2 
+        a(href="#{harvestUrl}")
+          i.fa.fa-caret-left
+        | Records for
+        = harvest.name
     .page-breadcrumbs
+      | / 
+      a(href="#{harvestUrl}")
+        = harvest.name
       | / Records
   .records.resource
     .container
@@ -34,7 +41,7 @@ template(name="recordsServicesCell")
     ul
       each services
         li
-          a(href=service_url)= service_type
+          a(href=service_url target='_blank')= service_type
 
 template(name="recordsErrorCell")
   a.collapse-errors(href='#')
@@ -54,7 +61,7 @@ template(name="recordsLink")
 
 
 template(name="recordsCKANLink")
-  a(href="{{getCatalogURL}}")
+  a(href="{{getCatalogURL}}" target="_blank")
     img.ckan-logo(alt="CKAN Logo" src="{{absoluteUrl 'images/logo-ckan.svg'}}")
 
 

--- a/app/imports/ui/pages/records/records.js
+++ b/app/imports/ui/pages/records/records.js
@@ -4,6 +4,7 @@ import { Template } from 'meteor/templating';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 import { Records, RecordsTable } from '/imports/api/records/records.js';
 import { ReactiveDict } from 'meteor/reactive-dict';
+import { Harvests } from '/imports/api/harvests/harvests.js';
 import { _ } from 'meteor/underscore';
 
 
@@ -17,6 +18,12 @@ Template.records.events({
 /* records: Helpers */
 /*****************************************************************************/
 Template.records.helpers({
+  harvestUrl: function() {
+    return FlowRouter.path('harvests', {harvestId: FlowRouter.getParam('harvestId')});
+  },
+  harvest: function() {
+    return Harvests.findOne({_id: Template.instance().harvestId});
+  },
   recordsTable: function() {
     return RecordsTable;
   },
@@ -39,10 +46,13 @@ Template.records.helpers({
 /*****************************************************************************/
 Template.records.onCreated(function() {
   this.state = new ReactiveDict();
+  this.state.set('errorCount', 0);
+  this.state.set('servicesCount', 0);
+  this.state.set('recordsCount', 0);
   this.harvestId = FlowRouter.getParam('harvestId');
-});
-
-Template.records.onRendered(function() {
+  this.autorun(() => {
+    this.subscribe('harvests.public');
+  });
   Meteor.call('records.errorCount', {harvestId: this.harvestId}, (err, res) => {
     if(err) {
       console.error(err);
@@ -64,6 +74,9 @@ Template.records.onRendered(function() {
       this.state.set('recordsCount', res);
     }
   });
+});
+
+Template.records.onRendered(function() {
 });
 
 Template.records.onDestroyed(function() {

--- a/app/imports/ui/stylesheets/resource.less
+++ b/app/imports/ui/stylesheets/resource.less
@@ -12,6 +12,10 @@
 }
 
 .resource {
+  .container.stretch {
+    width: 98%;
+  }
+
   background-color: @background-gray;
   padding-top: 20px;
   padding-bottom: 40px;


### PR DESCRIPTION
- Changes column heading from "published" to "online", online is a
  little more intuitive than published.
- Improved the query for aggregating error and service counts
- Adds ability to go to a harvests page with a harvest already selected
- Refactored the box layout to use the same layout functions as records
  page
- Errors box is now clickable and goes to the same page as records
- Fixes links to open new tabs
- Renames label on harvest page from "Records" to "Total Records"
- Renames label on harvest page from "Errors" to "Bad Records"
- Turns off clicking in pie chart
- Fixed bug where a template would render before the data would come
  back and
  cause "undefined" behavior in Chrome's ability to render. I got some
  crazy
  screenshots of some truly remarkable behavior.
- Updates breadcrumbs for records page to include the harvest title
- Updates title for records page to include harvest title
- Adds a left-caret in the records page to take the user back
