### PR TITLE
Sort organizations by name

### DIFF
--- a/app/imports/ui/pages/organizations/organizations.js
+++ b/app/imports/ui/pages/organizations/organizations.js
@@ -29,7 +29,7 @@ Template.organizations.events({
 /*****************************************************************************/
 Template.organizations.helpers({
   organizations() {
-    return Organizations.find({});
+    return Organizations.find({}, {sort: {name:1}});
   },
   pathTo(name) {
     return FlowRouter.path(name);


### PR DESCRIPTION
Before the orgs were ordered by whatever Mongo felt was appropriate.
