### PR TITLE
Adds CKAN count to about page

### DIFF
--- a/app/imports/ui/pages/about/about.jade
+++ b/app/imports/ui/pages/about/about.jade
@@ -27,12 +27,7 @@ template(name='about')
                   | API
                 | for all of our harvests.
 
-              h3
-                = recordCount
-                | Total Records
-
-              p.smaller
-                i ({{badRecordCount}}) Records with errors
+              +aboutCounts recordCount=recordCount ckanCount=ckanCount badRecordCount=badRecordCount
 
               +currentHarvestsTable data=harvests
 
@@ -57,3 +52,18 @@ template(name='currentHarvestsTable')
           td {{parseHarvestType harvest_type}}
 
 
+
+template(name='aboutCounts')
+  .row
+    .col-md-6.col-xs-12
+      h3
+        = recordCount
+        | Total Records
+      p.smaller
+        i ({{badRecordCount}}) Records with errors
+
+    .col-md-6.col-xs-12
+      if ckanCount
+        h3
+          = ckanCount
+          | CKAN Records


### PR DESCRIPTION
This commit adds a function to make an async HTTP request to CKAN's API
to fetch the current dataset count. It also breaks up the body of the
about template into another template called aboutCounts which deals with
the counts.